### PR TITLE
Update electron and electron-builder to latest stable versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "react-tap-event-plugin": "3.0.2"
   },
   "devDependencies": {
-    "electron": "^5.0.0",
-    "electron-builder": "20.25.0",
+    "electron": "^6.0.1",
+    "electron-builder": "21.2.0",
     "electron-packager": "^14.0.4"
   }
 }


### PR DESCRIPTION
I updated `electron` to latest v.6.0.1 and `electron-builder` to v.21.2.0. It's also compatible with `electron-packager` (which supports electron 6.0.+). I tested building both variants.

But as for me, it's better to deliver the app using `electron-builder`, because it creates installable `.dmg` file for macOS and generates files for Windows & Linux. Also, it might solve issues like https://github.com/onmyway133/PushNotifications/issues/19 in comparison with `electron-packager`.

**Important:**
For building with `electron-builder` you need to run `npm run dist`. Generated files end up in the folder `dist`.
For building with `electron-packager` you need to run `npm run release`. Generated files end up in the folder `PushNotifications-darwin-x64`.