### PR TITLE
Add support for `apns-push-type` which is required for delivering iOS 13 notifications

### DIFF
--- a/components/InputComponent.js
+++ b/components/InputComponent.js
@@ -159,7 +159,7 @@ class InputComponent extends React.Component {
       // If `content-available` equals 1 and `aps` dictionary doesn't contain any other keys, the notification is silent.
       // `apns-push-type` must be set to `background` for iOS 13+.
       const aps = json["aps"]
-      if (aps["content-available"] === 1) {
+      if (aps && aps["content-available"] === 1) {
         let size = 0, key
         for (key in aps) {
           size++

--- a/components/InputComponent.js
+++ b/components/InputComponent.js
@@ -153,14 +153,14 @@ class InputComponent extends React.Component {
     notification.pushType = "alert"
 
     try {
-      let json = JSON.parse(input.message)
+      const json = JSON.parse(input.message)
       notification.rawPayload = json
 
       // If `content-available` equals 1 and `aps` dictionary doesn't contain any other keys, the notification is silent.
       // `apns-push-type` must be set to `background` for iOS 13+.
-      let aps = json["aps"]
+      const aps = json["aps"]
       if (aps["content-available"] === 1) {
-        var size = 0, key
+        let size = 0, key
         for (key in aps) {
           size++
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,9 +228,8 @@
       }
     },
     "apn": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apn/-/apn-2.2.0.tgz",
-      "integrity": "sha512-YIypYzPVJA9wzNBLKZ/mq2l1IZX/2FadPvwmSv4ZeR0VH7xdNITQ6Pucgh0Uw6ZZKC+XwheaJ57DFZAhJ0FvPg==",
+      "version": "github:node-apn/node-apn#38a357ed0c153aad09c2857e48a710527e685bfc",
+      "from": "github:node-apn/node-apn#master",
       "requires": {
         "debug": "^3.1.0",
         "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
@@ -2099,9 +2098,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "apn": "^2.2.0",
+    "apn": "node-apn/node-apn#master",
     "electron-store": "^2.0.0",
     "fs-extra": "^8.1.0",
     "material-ui": "0.20.1",


### PR DESCRIPTION
Hi @onmyway133 
I updated `apn` to v.3.0.0 (not `npm` version for now, https://github.com/node-apn/node-apn/releases). 

It includes support for setting `apns-push-type` which is required for sending notifications to devices running iOS 13. I explained the necessity in the comments around code changes.
Also, I tested it manually.

Please, have a look. We need to release it, because iOS 13 is coming in several days.
I will attach build artifacts.