### PR TITLE
Fix voip push

### DIFF
--- a/components/InputComponent.js
+++ b/components/InputComponent.js
@@ -173,7 +173,9 @@ class InputComponent extends React.Component {
       // `apns-push-type` must be set to `background` for iOS 13+.
       // `category` key is an exeption to the rule
       const aps = json["aps"]
-      if (aps && aps["content-available"] === 1) {
+      if (input.bundleId.endsWith(".voip")) {
+        notification.pushType = "voip"
+      } else if (aps && aps["content-available"] === 1) {
         const maxKeysNumber = aps.hasOwnProperty("category") ? 2 : 1
 
         let size = 0, key


### PR DESCRIPTION
voip push (Sandbox Environment) seems to fail.
Set  apns-push-type to `voip` if voip push.

see: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/