### PR TITLE
Allow user to send data-only or custom notification payload

### DIFF
--- a/components/InputComponent.js
+++ b/components/InputComponent.js
@@ -268,6 +268,12 @@ class InputComponent extends React.Component {
         body: payload.body,
       },
     }
+    // data-only or custom notification payload
+    if ([payload.data, payload.notification].some(o => o && typeof o === 'object')) {
+      delete message.data
+      delete message.notification
+      Object.assign(message, payload)
+    }
 
     const options = {
       method: 'POST',


### PR DESCRIPTION
If payload.data or payload.notification is present, we merge the whole payload to the fcm message object.
This will solve the case user need to send data-only or custom notification payload

For eg:
```
{
  "data": {
    "title": "Title from data-only",
    "body": "Body from data-only",
    // ... Other data fields
  }
}
```