### PR TITLE
Adding support for iOS Live Activity push notifications

### DIFF
--- a/components/InputComponent.js
+++ b/components/InputComponent.js
@@ -198,6 +198,8 @@ class InputComponent extends React.Component {
         notification.pushType = "fileprovider"
       } else if (input.bundleId.endsWith(".voip")) {
         notification.pushType = "voip"
+      } else if (input.bundleId.endsWith(".liveactivity")) {
+        notification.pushType = "liveactivity"
       } else if (aps && aps["content-available"] === 1) {
         const maxKeysNumber = aps.hasOwnProperty("category") ? 2 : 1
 


### PR DESCRIPTION
## Background
As mentioned in these [Apple Docs](https://developer.apple.com/documentation/activitykit/update-and-end-your-live-activity-with-remote-push-notifications) about the upcoming Live Activities feature. This feature will support using APNs push notifications, for which some specific headers are required: 
- The `apns-topic` header should have the format `<your bundleID>.push-type.liveactivity`
- The `apns-push-type` header should be `liveactivity`.

## This PR
With this change, the Push Notifications app should support this new type of notifications, if users provide the correct apns-topic as bundleId (`<your bundleID>.push-type.liveactivity`).

Let me know if anything in the PR requires changing. This set up seems to work for me locally.